### PR TITLE
Railway Deployment #baf8bf fix: vite not found in production build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,26 +14,26 @@
     "@mediapipe/camera_utils": "^0.3.1675466862",
     "@mediapipe/drawing_utils": "^0.3.1675466124",
     "@mediapipe/pose": "^0.5.1675469404",
+    "@vitejs/plugin-react": "^4.4.1",
+    "autoprefixer": "^10.4.16",
     "axios": "^1.10.0",
     "lucide-react": "^0.519.0",
+    "postcss": "^8.4.32",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.6.2",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "tailwindcss": "^3.4.17",
+    "vite": "^6.3.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
-    "@vitejs/plugin-react": "^4.4.1",
-    "autoprefixer": "^10.4.16",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^16.0.0",
-    "postcss": "^8.4.32",
-    "tailwindcss": "^3.4.17",
-    "vite": "^6.3.5"
+    "globals": "^16.0.0"
   }
 }


### PR DESCRIPTION
## Problem

The Nixpacks build fails with `sh: 1: vite: not found` (exit code 127) because Nixpacks sets `NODE_ENV=production`, causing npm to skip `devDependencies` during `npm install --prefix frontend`. `vite`, `@vitejs/plugin-react`, `autoprefixer`, `postcss`, and `tailwindcss` were all in `devDependencies`, so they were never installed and `vite build` could not run.

## Solution

Moved `vite`, `@vitejs/plugin-react`, `autoprefixer`, `postcss`, and `tailwindcss` from `devDependencies` to `dependencies` in `frontend/package.json` so they are installed regardless of `NODE_ENV`. Linting-only packages remain in `devDependencies`. Also added `node_modules/` to `.gitignore` to prevent committed modules from causing snapshot bloat or version conflicts.

### Changes
- **Modified** `frontend/package.json`
- **Modified** `.gitignore`

### Context
- **Deployment**: [#baf8bf](https://railway.com/project/500a37c7-183b-4072-81b7-3355fcf9b717/environment/ada031fa-c4b5-416a-a7cc-5a8ef21a0636/deployment/baf8bf4e-3933-4063-8955-52a4727be70c)
- **Failed commit**: `ceb7ef9`

---
*Generated by [Railway](https://railway.com)*